### PR TITLE
Just use an equality check

### DIFF
--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -90,16 +90,8 @@ func (i intKey) Hash() uint32 {
 	return uint32(i - math.MaxUint32)
 }
 
-func (i intKey) Compare(v interface{}) int {
-	a := int(i)
-	b := int(v.(intKey))
-	if a < b {
-		return -1
-	}
-	if a == b {
-		return 0
-	}
-	return 1
+func (i intKey) Equal(v interface{}) bool {
+	return int(i) == int(v.(intKey))
 }
 
 func TestSimpleIntSet(t *testing.T) {

--- a/string.go
+++ b/string.go
@@ -1,9 +1,6 @@
 package dictionary
 
-import (
-	"hash/crc32"
-	"strings"
-)
+import "hash/crc32"
 
 // StringKey is a convinience type for using strings as keys in a dictionary
 type StringKey string
@@ -14,8 +11,8 @@ func (s StringKey) Hash() uint32 {
 }
 
 // Compare uses the stdlib strings.Compare to compare two string keys
-func (s StringKey) Compare(v interface{}) int {
-	return strings.Compare(string(s), string(v.(StringKey)))
+func (s StringKey) Equal(v interface{}) bool {
+	return string(s) == string(v.(StringKey))
 }
 
 // String returns the string value of the key


### PR DESCRIPTION
For some types that may be used as keys, it can be challenging to determine if one is greater or lesser than the other.  Also, the typical hash table implementations generally just use a simple equality check.  This also simplifies the search code.
